### PR TITLE
Render button on issues and PRs

### DIFF
--- a/data/js/content.js
+++ b/data/js/content.js
@@ -44,7 +44,7 @@ function composeDOM() {
 
     // insert into DOM //
     // locate file navigation
-    let nav = document.getElementsByClassName("file-navigation")[0];
+    let nav = document.getElementsByClassName("file-navigation")[0] || document.getElementsByClassName("gh-header-actions")[0];
 
     // insert element
     if (nav !== undefined) {


### PR DESCRIPTION
Fixes https://github.com/Cutwell/github1s-chrome-extension/issues/3

Using `github1s` to review PRs is very useful. However, at the moment I have to edit the URL in the browser in order to access `github1s`.

I'd like to be able to access the "Open in GitHub1s" button from a given PR. I think this feature is crucial to unlock the usefulness of `github1s`.
